### PR TITLE
Removed country from update Adyen store calls

### DIFF
--- a/src/core/process/stores.ts
+++ b/src/core/process/stores.ts
@@ -228,7 +228,10 @@ export const processAdyenStores = async ({
             storeId: store.adyenId,
           },
         })
-        await updateAdyenStore(appEnv, store.adyenId, adyenStore)
+        const { address, ...rest } = adyenStore
+        const { country, ...restAddress } = address
+        const updatedStore = { ...rest, address: restAddress }
+        await updateAdyenStore(appEnv, store.adyenId, updatedStore)
       } else if (!store.adyenId && store.status) {
         logger('process-adyen-stores').info({
           requestId,

--- a/src/core/process/stores.ts
+++ b/src/core/process/stores.ts
@@ -4,12 +4,12 @@ import { createAdyenStore, deactivateAdyenStore, updateAdyenStore } from '@eapis
 import { getLocations } from '@eapis/jdna.js'
 import { parseStoreRef } from '@util'
 import { logger } from '@util/logger.js'
+import { AxiosError } from 'axios'
 import { eq } from 'drizzle-orm'
 import { type AdyenStoreCreate, type AdyenStore } from 'types/adyen.js'
 import { type APP_ENVS } from '@/constants.js'
 import { AppError } from '@/error.js'
 import 'dotenv/config'
-import { AxiosError } from 'axios'
 
 export const getJDNAStores = async ({
   requestId,

--- a/src/eapis/adyen.ts
+++ b/src/eapis/adyen.ts
@@ -1,5 +1,6 @@
 import { logger } from '@util/logger.js'
 import axios from 'axios'
+import { type NestedOmit } from 'types'
 import {
   type AdyenStoreCreate,
   type AdyenStore,
@@ -10,7 +11,6 @@ import {
 
 import { type APP_ENVS } from '@/constants'
 import { AppError } from '@/error.js'
-import { NestedOmit } from 'types'
 
 const adyenConfig = (appEnv: (typeof APP_ENVS)[number]) => {
   const { ADYEN_KEY, ADYEN_KEY_LIVE, ADYEN_KEY_TEST } = process.env

--- a/src/eapis/adyen.ts
+++ b/src/eapis/adyen.ts
@@ -10,6 +10,7 @@ import {
 
 import { type APP_ENVS } from '@/constants'
 import { AppError } from '@/error.js'
+import { NestedOmit } from 'types'
 
 const adyenConfig = (appEnv: (typeof APP_ENVS)[number]) => {
   const { ADYEN_KEY, ADYEN_KEY_LIVE, ADYEN_KEY_TEST } = process.env
@@ -251,7 +252,7 @@ export const getAdyenTerminals = async ({
 export const updateAdyenStore = async (
   appEnv: (typeof APP_ENVS)[number],
   storeId: string,
-  store: AdyenStoreCreate,
+  store: NestedOmit<AdyenStoreCreate, 'address.country'>,
 ) => {
   const { ax } = adyenConfig(appEnv)
   const query = await ax.patch(`/stores/${storeId}`, store)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,14 @@ import { z } from 'zod'
 
 export type PromiseResolvedType<T> = T extends Promise<infer R> ? R : never
 
+export type NestedOmit<Schema, Path extends string> = Path extends `${infer Head}.${infer Tail}`
+  ? Head extends keyof Schema
+    ? {
+        [K in keyof Schema]: K extends Head ? NestedOmit<Schema[K], Tail> : Schema[K]
+      }
+    : Schema
+  : Omit<Schema, Path>
+
 export type Bindings = {
   APP_ENV: 'PROD' | 'prod' | 'QA' | 'qa' | 'DEV' | 'dev' | undefined
   DATABASE_URL?: string


### PR DESCRIPTION
Adyen patch from store does not allow updating the country field. So that attribute is now removed from the call.